### PR TITLE
Allow more configuration through env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,9 @@ to the ip of your docker daemon, we use `ngo.lol` here. Make sure to add
 Docker image has the following env variables for configuration:
 
 * `DEBUG`: if set, prints the generated nginx configuation on container start
-* `LOCATIONS` can contain `location` directives that will be injected into the nginx configuration on container start. If not set, a demo page is served under `location / {...}`
+* `LOCATIONS` can contain `location` directives that will be injected into the
+  nginx configuration on container start. If not set, a demo page is served
+  under `location / {...}`
 * `NGO_BLACKLIST` is the value of `$ngo_blacklist`.
 * `NGO_CALLBACK_HOST` is the value of `$ngo_callback_host`.
 * `NGO_CALLBACK_SCHEME` is the value of `$ngo_callback_scheme`.

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ this includes:
 
 You have to [obtain tokens](#Configuring OAuth access) first.
 
-There is a pre-build image: `cloudflare/nginx-google-oauth`. If you are
+There is a pre-built image: `cloudflare/nginx-google-oauth`. If you are
 hacking on this project, you might want to rebuild the image yourself.
 
 To make it work locally, add a record to DNS or to `/etc/hosts`, pointing
@@ -185,17 +185,29 @@ to the ip of your docker daemon, we use `ngo.lol` here. Make sure to add
 
 Docker image has the following env variables for configuration:
 
-* `PORT` is the port for nginx to listen on, defaults to `80`.
+* `DEBUG`: if set, prints the generated nginx configuation on container start
+* `LOCATIONS` can contain `location` directives that will be injected into the nginx configuration on container start. If not set, a demo page is served under `location / {...}`
+* `NGO_BLACKLIST` is the value of `$ngo_blacklist`.
+* `NGO_CALLBACK_HOST` is the value of `$ngo_callback_host`.
+* `NGO_CALLBACK_SCHEME` is the value of `$ngo_callback_scheme`.
+* `NGO_CALLBACK_SCHEME` is the value of `$ngo_callback_scheme`, required.
+* `NGO_CALLBACK_URI` is the value of `$ngo_callback_uri`.
 * `NGO_CLIENT_ID` is the value of `$ngo_client_id`, required.
 * `NGO_CLIENT_SECRET` is the value of `$ngo_client_secret`, required.
-* `NGO_TOKEN_SECRET` is the value of `$ngo_token_secret`, required.
-* `NGO_CALLBACK_SCHEME` is the value of `$ngo_callback_scheme`, required.
+* `NGO_DOMAIN` is the value of `$ngo_domain`.
+* `NGO_EMAIL_AS_USER` is the value of `$ngo_email_as_user`
 * `NGO_EXTRA_VALIDITY` is the value of `$ngo_extra_validity`, required.
+* `NGO_SECURE_COOKIES` is the value of `$ngo_secure_cookies`
+* `NGO_TOKEN_SECRET` is the value of `$ngo_token_secret`, required.
+* `NGO_USER` is the value of `$ngo_user`.
+* `NGO_WHITELIST` is the value of `$ngo_whitelist`.
+* `PORT` is the port for nginx to listen on, defaults to `80`.
 
 Run the image:
 
 ```
 docker run --rm -it --net host \
+  -e DEBUG=1 \
   -e NGO_CALLBACK_SCHEME=http \
   -e NGO_CLIENT_ID="client id from google" \
   -e NGO_CLIENT_SECRET="client secret from google" \

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash
 
 PORT=${PORT:-80}
 
@@ -19,13 +19,49 @@ if [ -z "${NGO_TOKEN_SECRET}" ]; then
   exit 1
 fi
 
+# Define some defaults
+NGO_CALLBACK_HOST=${NGO_CALLBACK_HOST-\$\{host\}}
 NGO_CALLBACK_SCHEME=${NGO_CALLBACK_SCHEME:-https}
+NGO_CALLBACK_URI=${NGO_CALLBACK_URI-/_oauth}
+NGO_EMAIL_AS_USER=${NGO_EMAIL_AS_USER:-true}
 NGO_EXTRA_VALIDITY=${NGO_EXTRA_VALIDITY:-0}
+NGO_USER=${NGO_USER:-unknown}
 
-sed "s/%client_id%/${NGO_CLIENT_ID}/"             -i /etc/nginx/sites-available/default
-sed "s/%client_secret%/${NGO_CLIENT_SECRET}/"     -i /etc/nginx/sites-available/default
-sed "s/%token_secret%/${NGO_TOKEN_SECRET}/"       -i /etc/nginx/sites-available/default
-sed "s/%callback_scheme%/${NGO_CALLBACK_SCHEME}/" -i /etc/nginx/sites-available/default
-sed "s/%extra_validity%/${NGO_EXTRA_VALIDITY}/"   -i /etc/nginx/sites-available/default
+# Default/demo location for nginx
+echo "# Default location, supply your own via -e LOCATIONS=...
+location / {
+  root /etc/nginx/demo;
+}
+" > /tmp/nginx-locations.conf
+
+# Overwrite user supplied locations
+if [ "${LOCATIONS}" ]; then
+  echo "#
+# Generated /tmp/nginx-locations.conf
+#
+${LOCATIONS}" > /tmp/nginx-locations.conf
+fi
+
+# Write config file
+sed "s/%NGO_BLACKLIST%/${BLACKLIST}/"                      -i /etc/nginx/sites-available/default && \
+  sed "s/%NGO_CALLBACK_HOST%/${NGO_CALLBACK_HOST-\$host}/" -i /etc/nginx/sites-available/default && \
+  sed "s/%NGO_CALLBACK_SCHEME%/${NGO_CALLBACK_SCHEME}/"    -i /etc/nginx/sites-available/default && \
+  sed "s|%NGO_CALLBACK_URI%|${NGO_CALLBACK_URI}|"          -i /etc/nginx/sites-available/default && \
+  sed "s/%NGO_CLIENT_ID%/${NGO_CLIENT_ID}/"                -i /etc/nginx/sites-available/default && \
+  sed "s/%NGO_CLIENT_SECRET%/${NGO_CLIENT_SECRET}/"        -i /etc/nginx/sites-available/default && \
+  sed "s/%NGO_DOMAIN%/${NGO_DOMAIN}/"                      -i /etc/nginx/sites-available/default && \
+  sed "s/%NGO_EMAIL_AS_USER%/${NGO_EMAIL_AS_USER}/"        -i /etc/nginx/sites-available/default && \
+  sed "s/%NGO_EXTRA_VALIDITY%/${NGO_EXTRA_VALIDITY}/"      -i /etc/nginx/sites-available/default && \
+  sed "s/%NGO_SECURE_COOKIES%/${NGO_SECURE_COOKIES}/"      -i /etc/nginx/sites-available/default && \
+  sed "s/%NGO_TOKEN_SECRET%/${NGO_TOKEN_SECRET}/"          -i /etc/nginx/sites-available/default && \
+  sed "s/%NGO_USER%/${NGO_USER}/"                          -i /etc/nginx/sites-available/default && \
+  sed "s/%NGO_WHITELIST%/${NGO_WHITELIST}/"                -i /etc/nginx/sites-available/default
+
+
+# Help people spot problems
+if [ $DEBUG ]; then
+  cat -n /etc/nginx/sites-available/default
+  cat -n /tmp/nginx-locations.conf
+fi
 
 exec nginx -g "daemon off;" -c /etc/nginx/nginx.conf

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh -e
 
 PORT=${PORT:-80}
 
@@ -43,19 +43,19 @@ ${LOCATIONS}" > /tmp/nginx-locations.conf
 fi
 
 # Write config file
-sed "s/%NGO_BLACKLIST%/${BLACKLIST}/"                      -i /etc/nginx/sites-available/default && \
-  sed "s/%NGO_CALLBACK_HOST%/${NGO_CALLBACK_HOST-\$host}/" -i /etc/nginx/sites-available/default && \
-  sed "s/%NGO_CALLBACK_SCHEME%/${NGO_CALLBACK_SCHEME}/"    -i /etc/nginx/sites-available/default && \
-  sed "s|%NGO_CALLBACK_URI%|${NGO_CALLBACK_URI}|"          -i /etc/nginx/sites-available/default && \
-  sed "s/%NGO_CLIENT_ID%/${NGO_CLIENT_ID}/"                -i /etc/nginx/sites-available/default && \
-  sed "s/%NGO_CLIENT_SECRET%/${NGO_CLIENT_SECRET}/"        -i /etc/nginx/sites-available/default && \
-  sed "s/%NGO_DOMAIN%/${NGO_DOMAIN}/"                      -i /etc/nginx/sites-available/default && \
-  sed "s/%NGO_EMAIL_AS_USER%/${NGO_EMAIL_AS_USER}/"        -i /etc/nginx/sites-available/default && \
-  sed "s/%NGO_EXTRA_VALIDITY%/${NGO_EXTRA_VALIDITY}/"      -i /etc/nginx/sites-available/default && \
-  sed "s/%NGO_SECURE_COOKIES%/${NGO_SECURE_COOKIES}/"      -i /etc/nginx/sites-available/default && \
-  sed "s/%NGO_TOKEN_SECRET%/${NGO_TOKEN_SECRET}/"          -i /etc/nginx/sites-available/default && \
-  sed "s/%NGO_USER%/${NGO_USER}/"                          -i /etc/nginx/sites-available/default && \
-  sed "s/%NGO_WHITELIST%/${NGO_WHITELIST}/"                -i /etc/nginx/sites-available/default
+sed "s/%NGO_BLACKLIST%/${BLACKLIST}/"                      -i /etc/nginx/sites-available/default
+sed "s/%NGO_CALLBACK_HOST%/${NGO_CALLBACK_HOST-\$host}/" -i /etc/nginx/sites-available/default
+sed "s/%NGO_CALLBACK_SCHEME%/${NGO_CALLBACK_SCHEME}/"    -i /etc/nginx/sites-available/default
+sed "s|%NGO_CALLBACK_URI%|${NGO_CALLBACK_URI}|"          -i /etc/nginx/sites-available/default
+sed "s/%NGO_CLIENT_ID%/${NGO_CLIENT_ID}/"                -i /etc/nginx/sites-available/default
+sed "s/%NGO_CLIENT_SECRET%/${NGO_CLIENT_SECRET}/"        -i /etc/nginx/sites-available/default
+sed "s/%NGO_DOMAIN%/${NGO_DOMAIN}/"                      -i /etc/nginx/sites-available/default
+sed "s/%NGO_EMAIL_AS_USER%/${NGO_EMAIL_AS_USER}/"        -i /etc/nginx/sites-available/default
+sed "s/%NGO_EXTRA_VALIDITY%/${NGO_EXTRA_VALIDITY}/"      -i /etc/nginx/sites-available/default
+sed "s/%NGO_SECURE_COOKIES%/${NGO_SECURE_COOKIES}/"      -i /etc/nginx/sites-available/default
+sed "s/%NGO_TOKEN_SECRET%/${NGO_TOKEN_SECRET}/"          -i /etc/nginx/sites-available/default
+sed "s/%NGO_USER%/${NGO_USER}/"                          -i /etc/nginx/sites-available/default
+sed "s/%NGO_WHITELIST%/${NGO_WHITELIST}/"                -i /etc/nginx/sites-available/default
 
 
 # Help people spot problems

--- a/docker/server.conf
+++ b/docker/server.conf
@@ -1,3 +1,6 @@
+#
+# Generated /etc/nginx/sites-available/default:
+#
 lua_package_path '/etc/nginx/lua/?.lua;';
 
 server {
@@ -11,15 +14,19 @@ server {
     error_log /dev/stderr notice;
     access_log /dev/stdout;
 
-    set $ngo_client_id       "%client_id%";
-    set $ngo_client_secret   "%client_secret%";
-    set $ngo_token_secret    "%token_secret%";
-    set $ngo_callback_host   $host;
-    set $ngo_callback_uri    "/_oauth";
-    set $ngo_callback_scheme "%callback_scheme%";
-    set $ngo_extra_validity  %extra_validity%;
-    set $ngo_user            "unknown";
-    set $ngo_email_as_user   true;
+    set $ngo_blacklist       "%NGO_BLACKLIST%";
+    set $ngo_callback_host   "%NGO_CALLBACK_HOST%";
+    set $ngo_callback_scheme "%NGO_CALLBACK_SCHEME%";
+    set $ngo_callback_uri    "%NGO_CALLBACK_URI%";
+    set $ngo_client_id       "%NGO_CLIENT_ID%";
+    set $ngo_client_secret   "%NGO_CLIENT_SECRET%";
+    set $ngo_domain          "%NGO_DOMAIN%";
+    set $ngo_email_as_user    %NGO_EMAIL_AS_USER%;
+    set $ngo_extra_validity   %NGO_EXTRA_VALIDITY%;
+    set $ngo_secure_cookies  "%NGO_SECURE_COOKIES%";
+    set $ngo_token_secret    "%NGO_TOKEN_SECRET%";
+    set $ngo_user            "%NGO_USER%";
+    set $ngo_whitelist       "%NGO_WHITELIST%";
 
     access_by_lua_file "/etc/nginx/lua/nginx-google-oauth/access.lua";
 
@@ -27,8 +34,6 @@ server {
 
     add_header Google-User $ngo_user;
 
-    # locations
-    location / {
-        root /etc/nginx/demo;
-    }
+    include /tmp/nginx-locations.conf;
+
 }


### PR DESCRIPTION
Allows to set the following variables from the lua plugin via
environment variables:

  - NGO_BLACKLIST
  - NGO_CALLBACK_HOST
  - NGO_CALLBACK_SCHEME
  - NGO_CALLBACK_URI
  - NGO_CLIENT_ID
  - NGO_CLIENT_SECRET
  - NGO_DOMAIN
  - NGO_EMAIL_AS_USER
  - NGO_EXTRA_VALIDITY
  - NGO_SECURE_COOKIES
  - NGO_TOKEN_SECRET
  - NGO_USER
  - NGO_WHITELIST

Also allows to supply a `LOCATIONS` environment variable to replace
the demo `location /`. This way you can use the same image for multiple
simple reverse proxies simply by setting environment variables.