### PR TITLE
Add multi-domain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ variables are:
 - **$ngo_secure_cookies** If defined, will ensure that cookies can only
   be transferred over a secure connection.
 - **$ngo_extra_validity** Time in seconds to add to token validity period.
-- **$ngo_domain** The domain to use for validating users when not using
-  white- or blacklists.
-- **$ngo_whitelist** Optional list of authorized email addresses.
-- **$ngo_blacklist** Optional list of unauthorized email addresses.
+-- **$ngo_domain** The space separated list of domains to use for validating
+   users when not using white- or blacklists.
+- **$ngo_whitelist** Optional space separated list of authorized email addresses.
+- **$ngo_blacklist** Optional space separated list of unauthorized email addresses.
 - **$ngo_user** If set, will be populated with the OAuth username
   returned from Google (portion left of '@' in email).
 - **$ngo_email_as_user** If set and `$ngo_user` is defined, username
@@ -171,6 +171,35 @@ this includes:
 * Headers for upstream servers
 * Lua scripts
 * etc.
+
+### Blacklist/Whitelist
+
+For blacklist the site, not even reach oauth, use this nginx example:
+
+```
+    access_by_lua_file "/etc/nginx/lua/nginx-google-oauth/access.lua";
+    deny your_blacklist_ip;
+    satisfy all
+```
+
+For whitelist (ie: disable oauth for this ip) use this works:
+
+```
+    access_by_lua_file "/etc/nginx/lua/nginx-google-oauth/access.lua";
+    allow your_whitelist_ip;
+    satisfy any;
+```
+
+Notice the satisfy any
+
+For allowing only one ip and block all others, but still oauth it, use this:
+
+```
+    access_by_lua_file "/etc/nginx/lua/nginx-google-oauth/access.lua";
+    allow your_whitelist_ip;
+    deny all;
+    satisfy all;
+```
 
 ### Docker image
 

--- a/access.lua
+++ b/access.lua
@@ -63,7 +63,7 @@ local function on_auth(email, token, expires)
 
   if not (whitelist or blacklist) then
     if domain:len() ~= 0 then
-      if oauth_domain ~= domain then
+      if not string.find(" " .. domain .. " ", " " .. oauth_domain .. " ") then
         ngx.log(ngx.ERR, email .. " is not on " .. domain)
         return ngx.exit(ngx.HTTP_FORBIDDEN)
       end

--- a/access.lua
+++ b/access.lua
@@ -177,6 +177,7 @@ local function is_authorized()
 end
 
 local function redirect_to_auth()
+  -- google seems to accept space separated domain list in the login_hint, so use this undocumented feature.
   return ngx.redirect("https://accounts.google.com/o/oauth2/auth?" .. ngx.encode_args({
     client_id     = client_id,
     scope         = "email",


### PR DESCRIPTION
..and updated the Readme to add the blacklist/whitelist examples

Notice that i'm sending the multi-domain list to the login_hint, but google seems to accept it and even choose the correct domain for the currently logged in user.
This looks like a undocumented feature, as it is a hint, should not cause any problem. If you prefer, you can change it to only send the first domain.