### PR TITLE
fix /_oauth requests if already authenticated

### DIFF
--- a/access.lua
+++ b/access.lua
@@ -246,3 +246,7 @@ handle_signout()
 if not is_authorized() then
   authorize()
 end
+
+-- if already authenticated, but still receives a /_oauth request, redirect to the correct destination
+if uri == "/_oauth" then
+  return ngx.redirect(uri_args["state"])


### PR DESCRIPTION
When nginx receives a request with /_oauth (maybe because of cache or pre-fetch), but the user is already authenticated, the request was "lost". Those requests should now be redirected to the final destination.