### PR TITLE
fixing compilation error

### DIFF
--- a/access.lua
+++ b/access.lua
@@ -250,3 +250,4 @@ end
 -- if already authenticated, but still receives a /_oauth request, redirect to the correct destination
 if uri == "/_oauth" then
   return ngx.redirect(uri_args["state"])
+end


### PR DESCRIPTION
there is a missing "end" which causes the error ```'end' expected (to close 'function' at line 1) near '<eof>',```