### PR TITLE
Max-Age sets cookies to expire N seconds in the future, rather than e…

### DIFF
--- a/access.lua
+++ b/access.lua
@@ -212,7 +212,7 @@ local function authorize()
   end
 
   local expires      = ngx.time() + token["expires_in"]
-  local cookie_tail  = ";version=1;path=/;Max-Age=" .. expires
+  local cookie_tail  = ";version=1;path=/;Max-Age=" .. token["expires_in"]
   if secure_cookies then
     cookie_tail = cookie_tail .. ";secure"
   end

--- a/access.lua
+++ b/access.lua
@@ -212,7 +212,7 @@ local function authorize()
   end
 
   local expires      = ngx.time() + token["expires_in"]
-  local cookie_tail  = ";version=1;path=/;Max-Age=" .. token["expires_in"]
+  local cookie_tail  = ";version=1;path=/;Max-Age=" .. extra_validity + token["expires_in"]
   if secure_cookies then
     cookie_tail = cookie_tail .. ";secure"
   end


### PR DESCRIPTION
Max-Age sets cookies to expire N seconds in the future, rather than expiring at a timestamp. In the current implementation, this results in OAuth cookies not expiring until the year 2065. This PR keeps the life of the cookie in sync with the life of the OAuth token, as appears to have been the intent of the original author.

See the Max-Age section of [this reference sheet from Mozilla](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie) for details.