### PR TITLE
fix whitelist not working if domain is not set

### DIFF
--- a/access.lua
+++ b/access.lua
@@ -70,6 +70,8 @@ local function check_domain(email, whitelist_failed)
       end
       return ngx.exit(ngx.HTTP_FORBIDDEN)
     end
+  elseif whitelist_failed then
+    return ngx.exit(ngx.HTTP_FORBIDDEN)
   end
 end
 


### PR DESCRIPTION
when domain is empty, and whitelist is fail, it is not return 403