### PR TITLE
Add cookie domain and ignore uri configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ variables are:
   returned from Google (portion left of '@' in email).
 - **$ngo_email_as_user** If set and `$ngo_user` is defined, username
   returned will be full email address.
+- **$ngo_cookie_domain** If defined, the chosen domain will be added to the
+  cookies, this can be useful for granting access to multiple subdomains.
+- **$ngo_ignore_uri** If defined, URIs containing this prefix will bypass
+  authentication.
 
 ## Available endpoints
 

--- a/access.lua
+++ b/access.lua
@@ -25,6 +25,8 @@ local secure_cookies    = ngx.var.ngo_secure_cookies == "true" or false
 local http_only_cookies = ngx.var.ngo_http_only_cookies == "true" or false
 local set_user          = ngx.var.ngo_user or false
 local email_as_user     = ngx.var.ngo_email_as_user == "true" or false
+local cookie_domain     = ngx.var.ngo_cookie_domain or ""
+local ignore_uri        = ngx.var.ngo_ignore_uri or ""
 
 if whitelist:len() == 0 then
   whitelist = nil
@@ -157,6 +159,10 @@ local function request_profile(token)
 end
 
 local function is_authorized()
+  if uri:sub(1, #ignore_uri) == ignore_uri then
+    return true
+  end
+
   local headers = ngx.req.get_headers()
 
   local expires = tonumber(ngx.var.cookie_OauthExpires) or 0
@@ -226,6 +232,9 @@ local function authorize()
   end
   if http_only_cookies then
     cookie_tail = cookie_tail .. ";httponly"
+  end
+  if cookie_domain ~= "" then
+    cookie_tail = cookie_tail .. ";Domain=" .. cookie_domain
   end
 
   local email      = profile["email"]


### PR DESCRIPTION
Add two new config variables:

- **$ngo_cookie_domain** If defined, the chosen domain will be added to the cookies, this can be useful for granting access to multiple subdomains.

- **$ngo_ignore_uri** If defined, URIs containing this prefix will bypass authentication.
