### PR TITLE
Prevent error when visiting "/_oauth" without state

### DIFF
--- a/access.lua
+++ b/access.lua
@@ -257,5 +257,9 @@ end
 
 -- if already authenticated, but still receives a /_oauth request, redirect to the correct destination
 if uri == "/_oauth" then
-  return ngx.redirect(uri_args["state"])
+  if uri_args["state"] then
+    return ngx.redirect(uri_args["state"])
+  else
+    return ngx.redirect("/")
+  end
 end


### PR DESCRIPTION
Before, if the user was already authenticated, visiting "/_oauth" without a "state" parameter would cause an exception. Automatically redirect to the root instead if the state parameter is not set.