### PR TITLE
Include server_tokens directive to hide nginx version

### DIFF
--- a/docker/etc-nginx/sites-available/default
+++ b/docker/etc-nginx/sites-available/default
@@ -11,6 +11,8 @@ server {
     lua_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
     lua_ssl_verify_depth        5;
 
+    server_tokens off;
+
     error_log /dev/stderr notice;
     access_log /dev/stdout;
 


### PR DESCRIPTION
When user is not authorized and is given a 404 page, nginx version is seen there.
This is security notice and should be considered properly.